### PR TITLE
Changed block subscription from finalized to best

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,16 @@ pub async fn subscribe_stats(
     url: &str,
 ) -> Result<impl TryStream<Ok = BlockStats, Error = Error> + Unpin, Error> {
     let client = OnlineClient::<DefaultConfig>::from_url(url).await?;
+    subscribe_stats_with_client(client).await
+}
+
+/// Connect to the specified node and listen for new blocks using OnlineClient.
+pub async fn subscribe_stats_with_client(
+    client: OnlineClient<DefaultConfig>,
+) -> Result<impl TryStream<Ok = BlockStats, Error = Error> + Unpin, Error> {
     let client = Arc::new(client);
 
-    let blocks = client.blocks().subscribe_finalized().await?;
+    let blocks = client.blocks().subscribe_best().await?;
 
     let max_block_weights: BlockWeights = {
         let metadata = client.metadata();


### PR DESCRIPTION
Changed subscription to best block to be aligned with change in smart-bench. Additionally added subscribe_stats_with_client to be able to pass mock implementation for unit tests.